### PR TITLE
CL compiler compat

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,9 +31,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         toolchain:
-          - {compiler: gcc, version: 11, cflags: '-Wall -Wextra -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -pedantic -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
-          - {compiler: gcc, version: 12, cflags: '-Wall -Wextra -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -pedantic -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
-          - {compiler: gcc, version: 13, cflags: '-Wall -Wextra -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -pedantic -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
+          - {compiler: gcc, version: 11, cflags: '-Wall -Wextra -Wpedantic -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
+          - {compiler: gcc, version: 12, cflags: '-Wall -Wextra -Wpedantic -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
+          - {compiler: gcc, version: 13, cflags: '-Wall -Wextra -Wpedantic -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
           - {compiler: intel-classic, version: '2021.7', cflags: '-diag-disable=10441', fflags: '-warn all -debug extended -fimplicit-none -standard-semantics -assume recursion'}
           - {compiler: intel-classic, version: '2021.8', cflags: '-diag-disable=10441', fflags: '-warn all -debug extended -fimplicit-none -standard-semantics -assume recursion'}
           - {compiler: intel-classic, version: '2021.9', cflags: '-diag-disable=10441', fflags: '-warn all -debug extended -fimplicit-none -standard-semantics -assume recursion'}
@@ -45,11 +45,11 @@ jobs:
           - os: ubuntu-latest
             toolchain: {compiler: intel, version: '2023.2', cflags: '', fflags: '-warn all -debug extended -fimplicit-none -standard-semantics -assume recursion'}
           - os: windows-latest
-            toolchain: {compiler: gcc, version: 11, cflags: '-Wall -Wextra -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -pedantic -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
+            toolchain: {compiler: gcc, version: 11, cflags: '-Wall -Wextra -Wpedantic -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
           - os: windows-latest
-            toolchain: {compiler: gcc, version: 12, cflags: '-Wall -Wextra -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -pedantic -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
+            toolchain: {compiler: gcc, version: 12, cflags: '-Wall -Wextra -Wpedantic -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
           - os: windows-latest
-            toolchain: {compiler: gcc, version: 13, cflags: '-Wall -Wextra -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -pedantic -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
+            toolchain: {compiler: gcc, version: 13, cflags: '-Wall -Wextra -Wpedantic -Werror', fflags: '-Wall -Wextra -Wpedantic -Werror -fimplicit-none -frecursive -fcheck=all -fstack-check -Wno-function-elimination'}
           - os: windows-latest
             toolchain: {compiler: intel, version: '2023.0', cflags: '', fflags: '/warn:all /debug:extended /Z7 /fimplicit-none /standard-semantics /assume:recursion'}
           - os: windows-latest
@@ -114,9 +114,9 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - {compiler: aflang, cflags: '-Wall', fflags: '-pedantic -Weverything -Wall -Wextra -Minform=warn -Mstandard -Mrecursive'}
+          - {compiler: aflang, cflags: '-Wall', fflags: '-Wpedantic -Weverything -Wall -Wextra -Minform=warn -Mstandard -Mrecursive'}
           - {compiler: nvfortran, cflags: '-Wall', fflags: '-C -Wall -Wextra -Minform=warn -Mstandard -Mrecursive -Mbounds -Mchkstk -Mchkptr'}
-          - {compiler: flang, cflags: '-Wall', fflags: '-pedantic -Weverything -Wall -Wextra'}
+          - {compiler: flang, cflags: '-Wall', fflags: '-Wpedantic -Weverything -Wall -Wextra'}
 
     steps:
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,11 +57,15 @@ jobs:
           - os: windows-latest
             toolchain: {compiler: intel, version: '2023.2', cflags: '', fflags: '/warn:all /debug:extended /Z7 /fimplicit-none /standard-semantics /assume:recursion'}
           - os: windows-latest
+            toolchain: {compiler: intel, version: '2023.2', cflags: '', fflags: '/warn:all /debug:extended /Z7 /fimplicit-none /standard-semantics /assume:recursion', cc: cl}
+          - os: windows-latest
             toolchain: {compiler: intel-classic, version: '2021.7', cflags: '/Qdiag-disable:10441', fflags: '/warn:all /debug:extended /Z7 /fimplicit-none /standard-semantics /assume:recursion'}
           - os: windows-latest
             toolchain: {compiler: intel-classic, version: '2021.8', cflags: '/Qdiag-disable:10441', fflags: '/warn:all /debug:extended /Z7 /fimplicit-none /standard-semantics /assume:recursion'}
           - os: windows-latest
             toolchain: {compiler: intel-classic, version: '2021.9', cflags: '/Qdiag-disable:10441', fflags: '/warn:all /debug:extended /Z7 /fimplicit-none /standard-semantics /assume:recursion'}
+          - os: windows-latest
+            toolchain: {compiler: intel-classic, version: '2021.9', cflags: '/Qdiag-disable:10441', fflags: '/warn:all /debug:extended /Z7 /fimplicit-none /standard-semantics /assume:recursion', cc: cl}
 
     steps:
 
@@ -90,6 +94,10 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
+
+      - name: Override C compiler
+        if: ${{ matrix.toolchain.cc }}
+        run: echo "CC=${{ matrix.toolchain.cc }}" >> $env:GITHUB_ENV
 
       - name: Build
         run: |

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ It can be compiled using CMake as follows.<a name="cmake"></a>
 ```bash
 git clone --depth 1 https://github.com/libprima/prima.git
 cd prima
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=install -DBUILD_SHARED_LIBS=OFF
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=install
 cmake --build build --target install
 ```
 This should create the `primaf` library for Fortran usage, located in the `install/lib/` directory

--- a/c/examples/cobyla/cobyla_example.c
+++ b/c/examples/cobyla/cobyla_example.c
@@ -5,6 +5,8 @@
 #include <math.h>
 #include <stdint.h>
 
+#define m_nlcon 1
+
 static void fun(const double x[], double *f, double constr[], const void *data)
 {
   const double x1 = x[0];
@@ -18,7 +20,6 @@ int main(int argc, char * argv[])
 {
   (void)argc;
   (void)argv;
-  const int m_nlcon = 1;
   const int n = 2;
   double x[2] = {0.0, 0.0};
   double f = 0.0;

--- a/c/tests/data.c
+++ b/c/tests/data.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 const int n = 2;
-const int m_nlcon = 1;
+#define m_nlcon 1
 int debug = 0;
 static int int_data = 0xff;
 const void * data_ref = &int_data;

--- a/c/tests/stress.c
+++ b/c/tests/stress.c
@@ -9,11 +9,11 @@
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
-const int n_max = 2000;
+#define n_max 2000
 int n = 0;
-const int m_ineq_max = 1000;
+#define m_ineq_max 1000
 int m_ineq = 0;
-const int m_nlcon = 200;
+#define m_nlcon 200
 const double alpha = 4.0;
 int debug = 0;
 


### PR DESCRIPTION
- Drop remaining use of vlas in tests
- Add CI tests for MS C compiler in combinations with intel fortran compilers.

