### PR TITLE
CMake: misc

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -2043,6 +2043,7 @@ endmacro
 evals
 primac
 primaf
+primafc
 cintrf
 COBJ
 COBJCON

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,19 +1,25 @@
-add_library (primac cintrf.f90 cobyla_c.f90 lincoa_c.f90 bobyqa_c.f90 newuoa_c.f90 uobyqa_c.f90 prima.c)
+# Fortran object files must be in a separate library as VS generator does not support mixing C and Fortran
+add_library (primafc OBJECT cintrf.f90 cobyla_c.f90 lincoa_c.f90 bobyqa_c.f90 newuoa_c.f90 uobyqa_c.f90)
+set_target_properties(primafc PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if (NOT BUILD_SHARED_LIBS)
+  target_link_libraries (primafc INTERFACE ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+endif ()
+target_link_libraries (primafc PUBLIC primaf) # must be PUBLIC for precision macros
+
+# now the C-only library
+add_library (primac prima.c)
 if (WIN32)
   set_target_properties(primac PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 endif()
-
-
 target_include_directories (primac PUBLIC
   $<INSTALL_INTERFACE:include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
-target_link_libraries (primac PUBLIC primaf) # must be PUBLIC for precision macros
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>>)
+target_link_libraries (primac PRIVATE primafc)
 set_target_properties(primac PROPERTIES POSITION_INDEPENDENT_CODE ON C_STANDARD 99)
-
 if (NOT BUILD_SHARED_LIBS)
   target_compile_definitions(primac PUBLIC PRIMAC_STATIC)
-  target_link_libraries (primac INTERFACE ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
 endif ()
 
 # Export symbols on Windows. See more comments in fortran/CMakeLists.txt.

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-set(CMAKE_C_STANDARD 99)
-
 add_library (primac cintrf.f90 cobyla_c.f90 lincoa_c.f90 bobyqa_c.f90 newuoa_c.f90 uobyqa_c.f90 prima.c)
 if (WIN32)
   set_target_properties(primac PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
@@ -30,6 +27,7 @@ macro (prima_add_c_test name)
   add_executable (example_${name}_c_exe EXCLUDE_FROM_ALL examples/${name}/${name}_example.c)
   target_link_libraries (example_${name}_c_exe PRIVATE primac)
   target_include_directories (example_${name}_c_exe PRIVATE ${CMAKE_SOURCE_DIR}/c/include)
+  set_target_properties(example_${name}_c_exe PROPERTIES C_STANDARD 99)
   if (PRIMA_ENABLE_EXAMPLES)
     set_target_properties (example_${name}_c_exe PROPERTIES EXCLUDE_FROM_ALL FALSE)
   endif ()

--- a/c/tests/CMakeLists.txt
+++ b/c/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 macro (prima_add_c_test_multi name)
   add_executable(${name}_c_exe EXCLUDE_FROM_ALL ${name}.c)
+  set_target_properties(${name}_c_exe PROPERTIES C_STANDARD 99)
   if (PRIMA_ENABLE_TESTING)
     set_target_properties (${name}_c_exe PROPERTIES EXCLUDE_FROM_ALL FALSE)
   endif ()


### PR DESCRIPTION
- Set C_STANDARD locally
- Split primac fortran sources in a separate library (not supported in some msvc configurations)
- Use generator expression for example location