### PR TITLE
Fix failing job on gcc 11

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -2134,3 +2134,5 @@ lang
 archnorma
 orthtol
 nouninit
+libgfortran
+chocolatey

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Install Ninja / MacOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: brew install ninja
+      - name: Install Ninja / Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install ninja
       - uses: fortran-lang/setup-fortran@main
         id: setup-fortran
         with:
@@ -99,6 +102,16 @@ jobs:
         if: ${{ matrix.toolchain.cc }}
         run: echo "CC=${{ matrix.toolchain.cc }}" >> $env:GITHUB_ENV
 
+      # gcc 12 is installed on windows runners by default. setup-fortran moves gfortran, gcc, and g++ to a temp directory
+      # so that they do not get picked up by CMake, but it doesn't move libgfortran-5.dll, and because /c/mingw64/bin is
+      # on the path ahead of /c/ProgramData/chocolatey/bin (setup-fortran uses chocolatey to install gcc11), the programs
+      # that are compiled with gcc11 try to use libgfortran-5.dll from gcc12 and crash. For now we rename the gcc12 version
+      # of libgfortran-5.dll so that the programs pick up the correct version in chocolatey/bin
+      - name: Move libgfortran-5.dll for gcc11 windows
+        if: ${{ matrix.os == 'windows-latest' && matrix.toolchain.compiler == 'gcc' && matrix.toolchain.version == '11' }} 
+        run: mv /c/mingw64/bin/libgfortran-5.dll /c/mingw64/bin/libgfortran-5.dll.old
+        shell: bash
+
       - name: Build
         run: |
           cmake --version
@@ -108,6 +121,7 @@ jobs:
           ctest --output-on-failure -V -j4 -E stress
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
+        shell: bash
 
       - name: Stress test
         if: ${{ github.event_name == 'schedule' || github.event.inputs.stress-test == 'true' }}


### PR DESCRIPTION
There's a comment in the .yml which describes the fix, but basically setup-fortran doesn't quite set up gcc 11 correctly. It's not quite their fault since the windows-latest image contains gcc 12 by default so they need to work around that and they didn't quite do it correctly.

What was happening is that the programs would get compiled with gcc 11, but when they ran, due to issues with how the PATH was set up, they would try to link against libgfortran-5.dll that was compiled with gcc 12 and this led to a crash. I tried to fix the PATH issues, but was unable to, so I decided to just rename the gcc 12 version of the dll so that it wouldn't get picked up.

I also noticed that the base image does not provide ninja, nor were the windows runners installing it explicitly. I'm not sure how it was installed, I think as a side effect of the setup-fortran action, but in any case I got some errors due to ninja not being installed so I went ahead and installed it explicitly.

Lastly I added the bash shell during some of my testing and I thought it was best to leave it there so that we can use bash across all 3 platforms for any future work.

This obviously supercedes https://github.com/libprima/prima/pull/115