### PR TITLE
Fixing gdb issue with gcc11 on Windows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -141,7 +141,6 @@ jobs:
           cmake --build . --target install
           cmake --build . --target tests
           ctest --output-on-failure -V -E stress
-          cat D:/a/prima/prima/cmdfile.gdb ||:
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,14 +36,16 @@ if (PRIMA_HEAP_ARRAYS)
   endif ()
 endif ()
 
-# For running tests with gdb. $_exitcode == -1 means the program ran without exiting
+# For running tests with gdb. $_exitcode != 0 means the program ran without exiting
 # normally, and in this case we want to show a stack trace
-file(WRITE ${CMAKE_BINARY_DIR}/cmdfile.gdb "init-if-undefined $_exitcode = -1
+file(WRITE ${CMAKE_BINARY_DIR}/cmdfile.gdb "init-if-undefined $_exitcode = 0
 run
-if $_exitcode == -1
+set language c
+if $_exitcode != 0
   where
 end
-quit $_exitcode")
+quit $_exitcode
+")
 
 option(PRIMA_ENABLE_EXAMPLES "build examples by default" OFF)
 add_custom_target (examples)


### PR DESCRIPTION
It complained "A syntax error in expression, near `= -1'."

Apparently gdb was evaluating the expressions in the command file as if they were in Fortran. Since Fortran 77 does not have "==" this produced a syntax error. Setting the language to C manually appears to resolve this.

It's also not entirely clear why we were looking for exitcode to be equal to -1. Some tests showed that if the exitcode were 2 this would be a problem, so we look at the more reasonable value of 0 instead.

Closes #151 