### PR TITLE
Update CMakeLists.txt to fix https://github.com/libprima/prima/issues/158

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif ()
 # Fix https://github.com/libprima/prima/issues/158, which is a failure due to the new linker 
 # implemented in Xcode 15 on macOS. It happens only if the Fortran compiler is ifort.  
 # An alternative is `add_link_options("-ld_classic")`, which forces Xcode to use the old linker.
-if((APPLE) AND (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel"))
+if((APPLE) AND (CMAKE_Fortran_COMPILER_ID MATCHES "Intel"))
     add_link_options("-Wl,-undefined,dynamic_lookup")
 endif()
 


### PR DESCRIPTION
The failure is due to the new linker implemented in Xcode 15. See 

https://stackoverflow.com/questions/77525544/apple-linker-warning-ld-warning-undefined-error-is-deprecated

https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking