### PR TITLE
Fix x0 and possible memory leak

### DIFF
--- a/c/prima.c
+++ b/c/prima.c
@@ -106,7 +106,7 @@ int prima_init_result(prima_result_t *result, prima_problem_t *problem)
     if (!result->x)
         return PRIMA_MEMORY_ALLOCATION_FAILS;
     for (int i = 0; i < problem->n; i++)
-        result->x[i] = NAN;
+        result->x[i] = problem->x0[i];
 
     // f: objective function value at the returned point
     result->f = NAN;
@@ -119,8 +119,10 @@ int prima_init_result(prima_result_t *result, prima_problem_t *problem)
         result->nlconstr = NULL;
     else {
         result->nlconstr = (double*)malloc(problem->m_nlcon * sizeof(double));
-        if (!result->nlconstr)
+        if (!result->nlconstr) {
+            free(result->x);
             return PRIMA_MEMORY_ALLOCATION_FAILS;
+        }
         for (int i = 0; i < problem->m_nlcon; i++)
             result->nlconstr[i] = NAN;
     }
@@ -244,10 +246,10 @@ int prima_minimize(const prima_algorithm_t algorithm, prima_problem_t *problem, 
 {
     int use_constr = (algorithm == PRIMA_COBYLA);
 
-    int info = prima_init_result(result, problem);
+    int info = prima_check_problem(problem, options, use_constr, algorithm);
 
     if (info == 0)
-        info = prima_check_problem(problem, options, use_constr, algorithm);
+        info = prima_init_result(result, problem);
 
     if (info == 0) {
         switch (algorithm) {


### PR DESCRIPTION
In https://github.com/libprima/prima/issues/148 the ability of the user to specify x0 from the C interface was removed. This PR fixes that. I noted this at the time in a comment in https://github.com/libprima/prima/commit/488abdabbf86931dcf83ad71d0c5b30ba5644825 but I suppose you missed it.

In the issue you objected to setting result->x to x0, but there is no other reasonable way to provide x0 to the Fortran code. In the issue you mentioned that result->x was set to a reasonable value even though no solver was selected, but the correct solution to that would be to have `prima_check_problem` return a non-zero exit code when it doesn't select a solver, as I mentioned in the issue.

Separately, I discuss this in my comment on the commit linked above as well, the modifications from that issue led to a possible memory leak. If `prima_init_result` returned 0 but `prima_check_problem` did not, we would return to the user with a non-zero exit code and also with allocated memory that the user would be expected to free. Of course it's not appropriate to both return a non-zero exit code and expect the user to clean up after us. The easiest way to solve this problem is to just check the problem before initializing the result.