### PR TITLE
Add additional const in prima.h and prima.c

### DIFF
--- a/c/include/prima/prima.h
+++ b/c/include/prima/prima.h
@@ -86,7 +86,7 @@ const char *prima_get_rc_string(const prima_rc_t rc);
  *         a NaN value can be passed to signal an evaluation error
  * data  : user data
  */
-typedef void (*prima_obj_t)(const double x[], double *f, const void *data);
+typedef void (*prima_obj_t)(const double x[], const double *f, const void *data);
 
 
 /*
@@ -99,7 +99,7 @@ typedef void (*prima_obj_t)(const double x[], double *f, const void *data);
  *          NaN values can be passed to signal evaluation errors
  * data  : user data
  */
-typedef void (*prima_objcon_t)(const double x[], double *f, double constr[], const void *data);
+typedef void (*prima_objcon_t)(const double x[], const double *f, double constr[], const void *data);
 
 
 /*
@@ -183,7 +183,7 @@ typedef struct {
 
 // Function to initialize the problem
 PRIMAC_API
-int prima_init_problem(prima_problem_t *problem, int n);
+int prima_init_problem(const prima_problem_t *problem, const int n);
 
 
 // Structure to hold the options
@@ -233,7 +233,7 @@ typedef struct {
 
 // Function to initialize the options
 PRIMAC_API
-int prima_init_options(prima_options_t *options);
+int prima_init_options(const prima_options_t *options);
 
 
 // Structure to hold the result
@@ -265,7 +265,7 @@ typedef struct {
 
 // Function to free the result
 PRIMAC_API
-int prima_free_result(prima_result_t *result);
+int prima_free_result(const prima_result_t *result);
 
 
 /*
@@ -277,7 +277,7 @@ int prima_free_result(prima_result_t *result);
  * return    : see prima_rc_t enum for return codes
  */
 PRIMAC_API
-int prima_minimize(const prima_algorithm_t algorithm, prima_problem_t *problem, prima_options_t *options, prima_result_t *result);
+int prima_minimize(const prima_algorithm_t algorithm, prima_problem_t *problem, prima_options_t *options, const prima_result_t *result);
 
 
 #ifdef __cplusplus

--- a/c/prima.c
+++ b/c/prima.c
@@ -34,7 +34,7 @@
 
 
 // Function to initialize the problem
-int prima_init_problem(prima_problem_t *problem, int n)
+int prima_init_problem(const prima_problem_t *problem, const int n)
 {
     if (!problem)
         return PRIMA_NULL_PROBLEM;
@@ -47,7 +47,7 @@ int prima_init_problem(prima_problem_t *problem, int n)
 
 
 // Function to initialize the options
-int prima_init_options(prima_options_t *options)
+int prima_init_options(const prima_options_t *options)
 {
     if (!options)
         return PRIMA_NULL_OPTIONS;
@@ -141,7 +141,7 @@ int prima_init_result(prima_result_t *result, prima_problem_t *problem)
 
 
 // Function to free the result
-int prima_free_result(prima_result_t *result)
+int prima_free_result(const prima_result_t *result)
 {
     if (!result)
         return PRIMA_NULL_RESULT;
@@ -217,23 +217,23 @@ const char *prima_get_rc_string(const prima_rc_t rc)
 
 
 // Functions implemented in Fortran (*_c.f90)
-int cobyla_c(const int m_nlcon, const prima_objcon_t calcfc, const void *data, const int n, double x[], double *f, double *cstrv, double nlconstr[],
+int cobyla_c(const int m_nlcon, const prima_objcon_t calcfc, const void *data, const int n, double x[], const double *f, double *cstrv, double nlconstr[],
             const int m_ineq, const double Aineq[], const double bineq[],
             const int m_eq, const double Aeq[], const double beq[],
             const double xl[], const double xu[],
             const double f0, const double nlconstr0[],
             int *nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int iprint, const prima_callback_t callback, int *info);
 
-int bobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *f, const double xl[], const double xu[],
+int bobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], const double *f, const double xl[], const double xu[],
             int *nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const prima_callback_t callback, int *info);
 
-int newuoa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *f,
+int newuoa_c(prima_obj_t calfun, const void *data, const int n, double x[], const double *f,
             int *nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const prima_callback_t callback, int *info);
 
-int uobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *f,
+int uobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], const double *f,
             int *nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int iprint, const prima_callback_t callback, int *info);
 
-int lincoa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *f,
+int lincoa_c(prima_obj_t calfun, const void *data, const int n, double x[], const double *f,
             double *cstrv,
             const int m_ineq, const double Aineq[], const double bineq[],
             const int m_eq, const double Aeq[], const double beq[],
@@ -242,7 +242,7 @@ int lincoa_c(prima_obj_t calfun, const void *data, const int n, double x[], doub
 
 
 // The function that does the minimization using a PRIMA solver
-int prima_minimize(const prima_algorithm_t algorithm, prima_problem_t *problem, prima_options_t *options, prima_result_t *result)
+int prima_minimize(const prima_algorithm_t algorithm, prima_problem_t *problem, prima_options_t *options, const prima_result_t *result)
 {
     int use_constr = (algorithm == PRIMA_COBYLA);
 


### PR DESCRIPTION
@zaikunzhang 
I checked all routines, except this one because it's a callback:
```c
typedef void (*prima_callback_t)(const int n, const double x[],
            const double f, int nf, int tr,
            const double cstrv, int m_nlcon,
            const double nlconstr[], bool *terminate);
```
I think that we can add `const` for all arguments.
What do you think?
