### PR TITLE
Make base algorithms (`cobyla`, `bobyqa`, etc.) directly available in the C API

### DIFF
--- a/c/include/prima/prima.h
+++ b/c/include/prima/prima.h
@@ -244,6 +244,30 @@ PRIMAC_API
 int prima_init_options(prima_options_t *const options);
 
 
+// Functions implemented in Fortran (*_c.f90)
+int cobyla_c(const int m_nlcon, const prima_objcon_t calcfc, const void *data, const int n, double x[], double *const f, double *const cstrv, double nlconstr[],
+             const int m_ineq, const double Aineq[], const double bineq[],
+             const int m_eq, const double Aeq[], const double beq[],
+             const double xl[], const double xu[],
+             const double f0, const double nlconstr0[],
+             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int iprint, const double ctol,
+             const prima_callback_t callback, int *const info);
+
+int bobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f, const double xl[], const double xu[],
+             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const prima_callback_t callback, int *const info);
+
+int newuoa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f,
+             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const prima_callback_t callback, int *const info);
+
+int uobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f,
+             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int iprint, const prima_callback_t callback, int *const info);
+
+int lincoa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f,
+             double *const cstrv, const int m_ineq, const double Aineq[], const double bineq[],
+             const int m_eq, const double Aeq[], const double beq[], const double xl[], const double xu[],
+             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const double ctol,
+             const prima_callback_t callback, int *const info);
+
 // Structure to hold the result
 // prima_minimize will allocate the memory for x and nlconstr (if needed),
 // and as such the user is expected to free the memory using prima_free_result

--- a/c/prima.c
+++ b/c/prima.c
@@ -203,32 +203,6 @@ const char *prima_get_rc_string(const prima_rc_t rc)
     }
 }
 
-
-// Functions implemented in Fortran (*_c.f90)
-int cobyla_c(const int m_nlcon, const prima_objcon_t calcfc, const void *data, const int n, double x[], double *const f, double *const cstrv, double nlconstr[],
-             const int m_ineq, const double Aineq[], const double bineq[],
-             const int m_eq, const double Aeq[], const double beq[],
-             const double xl[], const double xu[],
-             const double f0, const double nlconstr0[],
-             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int iprint, const double ctol,
-             const prima_callback_t callback, int *const info);
-
-int bobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f, const double xl[], const double xu[],
-             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const prima_callback_t callback, int *const info);
-
-int newuoa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f,
-             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const prima_callback_t callback, int *const info);
-
-int uobyqa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f,
-             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int iprint, const prima_callback_t callback, int *const info);
-
-int lincoa_c(prima_obj_t calfun, const void *data, const int n, double x[], double *const f,
-             double *const cstrv, const int m_ineq, const double Aineq[], const double bineq[],
-             const int m_eq, const double Aeq[], const double beq[], const double xl[], const double xu[],
-             int *const nf, const double rhobeg, const double rhoend, const double ftarget, const int maxfun, const int npt, const int iprint, const double ctol,
-             const prima_callback_t callback, int *const info);
-
-
 // The function that does the minimization using a PRIMA solver
 int prima_minimize(const prima_algorithm_t algorithm, const prima_problem_t problem, const prima_options_t options, prima_result_t *const result)
 {


### PR DESCRIPTION
This patch simply moves the definitions of `cobyla_c`, `bobyqa_c`, etc. from `prima.c` to `prima.h`.

 It is not that the new high level interface is bad (on the contrary, it may greatly simplify the life a C user) but the other functions (formerly `prima_bobyqa`,  `prima_newuoa`, etc.) have their utility. For instance, it may be easier to write langage bindings for the base algorithms because you do not have to deal with C structures, it is just needed to wrap function calls with simple arguments like values, and pointers to functions or to arrays. In that respect, updating the Julia interface in [`PRIMA.jl`](https://github.com/libprima/PRIMA.jl) would represent a lot of work and potentially new bugs (see this [PR](https://github.com/libprima/PRIMA.jl/pull/29#top)).

I would suggest to keep the same name as before, e.g. `prima_bobyqa` instead of `bobyqa_c`, but that's of lesser importance.