### PR TITLE
Alternative C API

### DIFF
--- a/c/examples/bobyqa/bobyqa_example.c
+++ b/c/examples/bobyqa/bobyqa_example.c
@@ -57,7 +57,7 @@ int main(int argc, char * argv[])
 
     // Call the solver
     prima_result_t result;
-    const int rc = prima_minimize(PRIMA_BOBYQA, problem, options, &result);
+    const int rc = prima_minimize(PRIMA_BOBYQA, &problem, &options, &result);
 
     // Print the result
     printf("x* = {%g, %g}, rc = %d, msg = '%s', evals = %d\n", result.x[0], result.x[1], rc, result.message, result.nf);

--- a/c/examples/cobyla/cobyla_example.c
+++ b/c/examples/cobyla/cobyla_example.c
@@ -64,7 +64,7 @@ int main(int argc, char * argv[])
 
     // Call the solver
     prima_result_t result;
-    const int rc = prima_minimize(PRIMA_COBYLA, problem, options, &result);
+    const int rc = prima_minimize(PRIMA_COBYLA, &problem, &options, &result);
 
     // Print the result
     printf("x* = {%g, %g}, f* = %g, cstrv = %g, nlconstr = {%g}, rc = %d, msg = '%s', evals = %d\n", result.x[0], result.x[1], result.f, result.cstrv, result.nlconstr[0], rc, result.message, result.nf);

--- a/c/examples/lincoa/lincoa_example.c
+++ b/c/examples/lincoa/lincoa_example.c
@@ -58,7 +58,7 @@ int main(int argc, char * argv[])
 
     // Call the solver
     prima_result_t result;
-    const int rc = prima_minimize(PRIMA_LINCOA, problem, options, &result);
+    const int rc = prima_minimize(PRIMA_LINCOA, &problem, &options, &result);
 
     // Print the result
     printf("x* = {%g, %g}, f* = %g, cstrv = %g, rc = %d, msg = '%s', evals = %d\n", result.x[0], result.x[1], result.f, result.cstrv, rc, result.message, result.nf);

--- a/c/examples/newuoa/newuoa_example.c
+++ b/c/examples/newuoa/newuoa_example.c
@@ -52,7 +52,7 @@ int main(int argc, char * argv[])
 
     // Call the solver
     prima_result_t result;
-    const int rc = prima_minimize(PRIMA_NEWUOA, problem, options, &result);
+    const int rc = prima_minimize(PRIMA_NEWUOA, &problem, &options, &result);
 
     // Print the result
     printf("x* = {%g, %g}, rc = %d, msg = '%s', evals = %d\n", result.x[0], result.x[1], rc, result.message, result.nf);

--- a/c/examples/uobyqa/uobyqa_example.c
+++ b/c/examples/uobyqa/uobyqa_example.c
@@ -52,7 +52,7 @@ int main(int argc, char * argv[])
 
     // Run the solver
     prima_result_t result;
-    const int rc = prima_minimize(PRIMA_UOBYQA, problem, options, &result);
+    const int rc = prima_minimize(PRIMA_UOBYQA, &problem, &options, &result);
 
     // Print the result
     printf("x* = {%g, %g}, rc = %d, msg = '%s', evals = %d\n", result.x[0], result.x[1], rc, result.message, result.nf);

--- a/c/include/prima/prima.h
+++ b/c/include/prima/prima.h
@@ -185,7 +185,6 @@ typedef struct {
 PRIMAC_API
 int prima_init_problem(prima_problem_t *const problem, const int n);
 
-
 // Structure to hold the options
 // In the following, "Default" refers to the value set by `prima_init_options`.
 typedef struct {
@@ -291,7 +290,7 @@ int prima_free_result(prima_result_t *const result);
  * return    : see prima_rc_t enum for return codes
  */
 PRIMAC_API
-int prima_minimize(const prima_algorithm_t algorithm, const prima_problem_t problem, const prima_options_t options, prima_result_t *const result);
+int prima_minimize(const prima_algorithm_t algorithm, const prima_problem_t *problem, const prima_options_t *options, prima_result_t *const result);
 
 
 #ifdef __cplusplus

--- a/c/include/prima/prima.h
+++ b/c/include/prima/prima.h
@@ -293,6 +293,123 @@ PRIMAC_API
 int prima_minimize(const prima_algorithm_t algorithm, const prima_problem_t *problem, const prima_options_t *options, prima_result_t *const result);
 
 
+typedef struct {
+    prima_algorithm_t algorithm;
+    prima_problem_t problem;
+    prima_options_t options;
+    prima_result_t result;
+} prima_context_t;
+
+PRIMAC_API
+prima_context_t* prima_context_create(const int n);
+
+PRIMAC_API
+void prima_context_destroy(prima_context_t* context);
+
+PRIMAC_API
+int prima_context_solve(prima_algorithm_t algorithm, prima_context_t* context);
+
+/* Accessors. */
+
+PRIMAC_API
+int prima_context_set_callfun(prima_context_t* context, prima_obj_t calfun, void* data);
+
+PRIMAC_API
+int prima_context_set_calcfc(prima_context_t* context, prima_objcon_t calcfc, void* data, int m_nlcon);
+
+PRIMAC_API
+int prima_context_set_x0(prima_context_t* context, double *x0);
+
+PRIMAC_API
+int prima_context_set_bounds(prima_context_t* context, double *xl, double *xu);
+
+PRIMAC_API
+int prima_context_set_ineq(prima_context_t* context, int m_ineq, double Aineq[], double *bineq);
+
+PRIMAC_API
+int prima_context_set_eq(prima_context_t* context, int m_eq, double Aeq[], double *beq);
+
+PRIMAC_API
+int prima_context_set_f0(prima_context_t* context, double f0);
+
+PRIMAC_API
+int prima_context_set_nlconstr0(prima_context_t* context, double* nlconstr0);
+
+PRIMAC_API
+int prima_context_get_n(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_get_m_ineq(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_get_m_eq(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_get_m_nlcon(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_set_rho(prima_context_t* context, double rhobeg, double rhoend);
+
+PRIMAC_API
+double prima_context_get_rhobeg(const prima_context_t* context);
+
+PRIMAC_API
+double prima_context_get_rhoend(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_set_maxfun(prima_context_t* context, int maxfun);
+
+PRIMAC_API
+int prima_context_get_maxfun(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_set_iprint(prima_context_t* context, int iprint);
+
+PRIMAC_API
+int prima_context_get_iprint(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_set_npt(prima_context_t* context, int npt);
+
+PRIMAC_API
+int prima_context_get_npt(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_set_ftarget(prima_context_t* context, double ftarget);
+
+PRIMAC_API
+double prima_context_get_ftarget(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_set_ctol(prima_context_t* context, double ctol);
+
+PRIMAC_API
+double prima_context_get_ctol(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_set_callback(prima_context_t* context, prima_callback_t callback);
+
+PRIMAC_API
+double* prima_context_get_x(const prima_context_t* context);
+
+PRIMAC_API
+double prima_context_get_f(const prima_context_t* context);
+
+PRIMAC_API
+double prima_context_get_cstrv(const prima_context_t* context);
+
+PRIMAC_API
+double* prima_context_get_nlconstr(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_get_nf(const prima_context_t* context);
+
+PRIMAC_API
+int prima_context_get_status(const prima_context_t* context);
+
+PRIMAC_API
+const char* prima_context_get_message(const prima_context_t* context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c/prima.c
+++ b/c/prima.c
@@ -288,3 +288,225 @@ int prima_minimize(const prima_algorithm_t algorithm, const prima_problem_t *pro
 
     return info;
 }
+
+prima_context_t* prima_context_create(const int n)
+{
+    size_t size = sizeof(prima_context_t);
+    prima_context_t* context = malloc(size);
+    if (context == NULL) {
+        return NULL;
+    }
+    memset(context, 0, size);
+    if (prima_init_problem(&context->problem, n) != 0 ||
+        prima_init_options(&context->options) != 0 ||
+        prima_init_result(&context->result, &context->problem) != 0) {
+        /* some error occurred */
+        prima_context_destroy(context);
+        return NULL;
+    }
+    return context;
+}
+
+void prima_context_destroy(prima_context_t* context)
+{
+    if (context != NULL) {
+        prima_free_result(&context->result);
+        free(context);
+    }
+}
+
+int prima_context_solve(prima_algorithm_t algorithm, prima_context_t* context)
+{
+    return prima_minimize(algorithm, &context->problem, &context->options, &context->result);
+}
+
+/* Accessors. */
+
+int prima_context_set_callfun(prima_context_t* context, prima_obj_t calfun, void* data)
+{
+    context->problem.calfun = calfun;
+    context->options.data = data;
+    return 0;
+}
+
+int prima_context_set_calcfc(prima_context_t* context, prima_objcon_t calcfc, void* data, int m_nlcon)
+{
+    context->problem.calcfc = calcfc;
+    context->problem.m_nlcon = m_nlcon;
+    context->options.data = data;
+    return 0;
+}
+
+int prima_context_set_x0(prima_context_t* context, double *x0)
+{
+    context->problem.x0 = x0;
+    return 0;
+}
+
+int prima_context_set_bounds(prima_context_t* context, double *xl, double *xu)
+{
+    context->problem.xl = xl;
+    context->problem.xu = xu;
+    return 0;
+}
+
+int prima_context_set_ineq(prima_context_t* context, int m_ineq, double Aineq[], double *bineq)
+{
+    context->problem.m_ineq = m_ineq;
+    context->problem.Aineq = Aineq;
+    context->problem.bineq = bineq;
+    return 0;
+}
+
+int prima_context_set_eq(prima_context_t* context, int m_eq, double Aeq[], double *beq)
+{
+    context->problem.m_eq = m_eq;
+    context->problem.Aeq = Aeq;
+    context->problem.beq = beq;
+    return 0;
+}
+
+int prima_context_set_f0(prima_context_t* context, double f0)
+{
+    context->problem.f0 = f0;
+    return 0;
+}
+
+int prima_context_set_nlconstr0(prima_context_t* context, double* nlconstr0)
+{
+    context->problem.nlconstr0 = nlconstr0;
+    return 0;
+}
+
+int prima_context_get_n(const prima_context_t* context)
+{
+    return context->problem.n;
+}
+
+int prima_context_get_m_ineq(const prima_context_t* context)
+{
+    return context->problem.m_ineq;
+}
+
+int prima_context_get_m_eq(const prima_context_t* context)
+{
+    return context->problem.m_eq;
+}
+
+int prima_context_get_m_nlcon(const prima_context_t* context)
+{
+    return context->problem.m_nlcon;
+}
+
+int prima_context_set_rho(prima_context_t* context, double rhobeg, double rhoend)
+{
+    context->options.rhobeg = rhobeg;
+    context->options.rhoend = rhoend;
+    return 0;
+}
+
+double prima_context_get_rhobeg(const prima_context_t* context)
+{
+    return context->options.rhobeg;
+}
+
+double prima_context_get_rhoend(const prima_context_t* context)
+{
+    return context->options.rhoend;
+}
+
+int prima_context_set_maxfun(prima_context_t* context, int maxfun)
+{
+    context->options.maxfun = maxfun;
+    return 0;
+}
+
+int prima_context_get_maxfun(const prima_context_t* context)
+{
+    return context->options.maxfun;
+}
+
+int prima_context_set_iprint(prima_context_t* context, int iprint)
+{
+    context->options.iprint = iprint;
+    return 0;
+}
+
+int prima_context_get_iprint(const prima_context_t* context)
+{
+    return context->options.iprint;
+}
+
+int prima_context_set_npt(prima_context_t* context, int npt)
+{
+    context->options.npt = npt;
+    return 0;
+}
+
+int prima_context_get_npt(const prima_context_t* context)
+{
+    return context->options.npt;
+}
+
+int prima_context_set_ftarget(prima_context_t* context, double ftarget)
+{
+    context->options.ftarget = ftarget;
+    return 0;
+}
+
+double prima_context_get_ftarget(const prima_context_t* context)
+{
+    return context->options.ftarget;
+}
+
+int prima_context_set_ctol(prima_context_t* context, double ctol)
+{
+    context->options.ctol = ctol;
+    return 0;
+}
+
+double prima_context_get_ctol(const prima_context_t* context)
+{
+    return context->options.ctol;
+}
+
+int prima_context_set_callback(prima_context_t* context, prima_callback_t callback)
+{
+    context->options.callback = callback;
+    return 0;
+}
+
+double* prima_context_get_x(const prima_context_t* context)
+{
+    return context->result.x;
+}
+
+double prima_context_get_f(const prima_context_t* context)
+{
+    return context->result.f;
+}
+
+double prima_context_get_cstrv(const prima_context_t* context)
+{
+    return context->result.cstrv;
+}
+
+double* prima_context_get_nlconstr(const prima_context_t* context)
+{
+    return context->result.nlconstr;
+}
+
+int prima_context_get_nf(const prima_context_t* context)
+{
+    return context->result.nf;
+}
+
+int prima_context_get_status(const prima_context_t* context)
+{
+    return context->result.status;
+}
+
+const char* prima_context_get_message(const prima_context_t* context)
+{
+    return context->result.message;
+}


### PR DESCRIPTION
This PR implements the alternative C API discussed [here](https://github.com/libprima/PRIMA.jl/pull/29) and [here](https://github.com/libprima/prima/pull/183). The changes come in two commits:

- the first commit (0aa20694383602cb69918fa13fa4b311d6669c0b) is a simple modification of the existing C API so that all structures are passed by address (not by value);

- the second commit (d90d0a3b5f13c65f50309ea33571596d24e4c14a) implements a draft of the proposed alternative C API with:
  - a single **opaque structure** `prima_context_t` storing all the parameters,
  - a couple of functions (`prima_context_create` and `prima_context_destroy` to create this structure and, when no longer needed, destroy it as well as related resources),
  - a number of functions (mutators `prima_context_set_...` and accessors  `prima_context_get_...`) to set and retrieve all parameters.  
 
All C examples compile and run fine with the first commit. Example are needed for the 2nd commit but it is mainly there for being discussed.