### PR TITLE
Refactor prima_is_success to accept options.ctol

### DIFF
--- a/c/cobyla_c.f90
+++ b/c/cobyla_c.f90
@@ -71,6 +71,7 @@ real(RP) :: Aineq_loc(m_ineq, n)
 real(RP) :: beq_loc(m_eq)
 real(RP) :: bineq_loc(m_ineq)
 real(RP) :: cstrv_loc
+real(RP) :: ctol_loc
 real(RP) :: f_loc
 real(RP) :: ftarget_loc
 real(RP) :: nlconstr_loc(m_nlcon)
@@ -79,7 +80,6 @@ real(RP), allocatable :: f0_loc
 real(RP), allocatable :: nlconstr0_loc(:)
 real(RP), allocatable :: rhobeg_loc
 real(RP), allocatable :: rhoend_loc
-real(RP), allocatable :: ctol_loc
 real(RP), allocatable :: xl_loc(:)
 real(RP), allocatable :: xu_loc(:)
 
@@ -131,9 +131,7 @@ if (maxfun /= 0) then
     maxfun_loc = int(maxfun, kind(maxfun_loc))
 end if
 iprint_loc = int(iprint, kind(iprint_loc))
-if (.not. is_nan(ctol)) then
-    ctol_loc = real(ctol, kind(ctol_loc))
-end if
+ctol_loc = real(ctol, kind(ctol_loc))
 
 ! Call the Fortran code
 if (c_associated(callback_ptr)) then

--- a/c/include/prima/prima.h
+++ b/c/include/prima/prima.h
@@ -300,7 +300,7 @@ prima_rc_t prima_minimize(const prima_algorithm_t algorithm, const prima_problem
 
 // Function to check if PRIMA returned normally or ran into abnormal conditions
 PRIMAC_API
-bool prima_is_success(const prima_result_t result);
+bool prima_is_success(const prima_result_t result, const prima_options_t options);
 
 #ifdef __cplusplus
 }

--- a/c/lincoa_c.f90
+++ b/c/lincoa_c.f90
@@ -68,12 +68,12 @@ real(RP) :: Aineq_loc(m_ineq, n)
 real(RP) :: beq_loc(m_eq)
 real(RP) :: bineq_loc(m_ineq)
 real(RP) :: cstrv_loc
+real(RP) :: ctol_loc
 real(RP) :: f_loc
 real(RP) :: ftarget_loc
 real(RP) :: x_loc(n)
 real(RP), allocatable :: rhobeg_loc
 real(RP), allocatable :: rhoend_loc
-real(RP), allocatable :: ctol_loc
 real(RP), allocatable :: xl_loc(:)
 real(RP), allocatable :: xu_loc(:)
 
@@ -120,9 +120,7 @@ if (npt /= 0) then
     npt_loc = int(npt, kind(npt_loc))
 end if
 iprint_loc = int(iprint, kind(iprint_loc))
-if (.not. is_nan(ctol)) then
-    ctol_loc = real(ctol, kind(ctol_loc))
-end if
+ctol_loc = real(ctol, kind(ctol_loc))
 
 ! Call the Fortran code
 if (c_associated(callback_ptr)) then

--- a/c/prima.c
+++ b/c/prima.c
@@ -57,7 +57,7 @@ prima_rc_t prima_init_options(prima_options_t *const options)
     options->rhoend = NAN;  // Will be interpreted by Fortran as not present
     options->iprint = PRIMA_MSG_NONE;
     options->ftarget = -INFINITY;
-    options->ctol = NAN;  // Will be interpreted by Fortran as not present
+    options->ctol = sqrt(DBL_EPSILON);
     return PRIMA_RC_DFT;
 }
 
@@ -268,8 +268,8 @@ prima_rc_t prima_minimize(const prima_algorithm_t algorithm, const prima_problem
     return info;
 }
 
-bool prima_is_success(const prima_result_t result)
+bool prima_is_success(const prima_result_t result, const prima_options_t options)
 {
-    return (result.status == PRIMA_SMALL_TR_RADIUS ||
-            result.status == PRIMA_FTARGET_ACHIEVED) && (result.cstrv <= sqrt(DBL_EPSILON));
+    return ((result.status == PRIMA_SMALL_TR_RADIUS && result.cstrv <= options.ctol) ||
+            (result.status == PRIMA_FTARGET_ACHIEVED));
 }

--- a/python/_prima.cpp
+++ b/python/_prima.cpp
@@ -30,9 +30,10 @@ class SelfCleaningPyObject {
 
 struct PRIMAResult {
     // Construct PRIMAResult from prima_result_t
-    PRIMAResult(const prima_result_t& result, const int num_vars, const int num_constraints, const std::string method)  :
+    PRIMAResult(const prima_result_t& result, const int num_vars, const int num_constraints, const std::string method,
+                const prima_options_t& options)  :
     x(num_vars, result.x),
-    success(prima_is_success(result)),
+    success(prima_is_success(result, options)),
     status(result.status),
     message(result.message),
     fun(result.f),
@@ -325,7 +326,7 @@ PYBIND11_MODULE(_prima, m) {
       // Initialize the result, call the function, convert the return type, and return it.
       prima_result_t result;
       const prima_rc_t rc = prima_minimize(algorithm, problem, options, &result);
-      PRIMAResult result_copy(result, py_x0.size(), problem.m_nlcon, method.cast<std::string>());
+      PRIMAResult result_copy(result, py_x0.size(), problem.m_nlcon, method.cast<std::string>(), options);
       prima_free_result(&result);
       return result_copy;
     }, "fun"_a, "x0"_a, "args"_a=py::tuple(), "method"_a=py::none(),


### PR DESCRIPTION
This is in reference to https://github.com/libprima/prima/issues/195

I made it so that ctol is initialized to the default value that was being used. Another option is to check if options.ctol is NaN within `prima_is_success`, but I know we've discussed before that `isnan` can have issues with certain optimization levels.

I'll think about it some more, but I'm not sure what other options there are. With either option above we need to maintain a default value within `prima.c` which is not ideal since that implies two places where default values are stored (`prima.c` and `consts.f90`). Would it make sense to have a `consts` folder at the root of the repo, which then contains folders like `fortran`, `c`, `python`, each of which defines const values for each of the languages, so that there's one place where these values are maintained?