### PR TITLE
Refactor calcfc_internal to remove nested function

### DIFF
--- a/fortran/cobyla/cobyla.f90
+++ b/fortran/cobyla/cobyla.f90
@@ -499,13 +499,14 @@ call safealloc(constr_loc, m)  ! NOT removable even in F2003!
 ! If NLCONSTR0 is present, then F0 must be present, and we assume that F(X0) = F0 even if F0 is NaN.
 ! If NLCONSTR0 is absent, then F0 must be either absent or NaN, both of which will be interpreted as
 ! F(X0) is not provided and we have to evaluate F(X0) and NLCONSTR(X0) now.
-constr_loc(1:m - m_nlcon) = moderatec(matprod(x, amat) - bvec)
 if (present(f0) .and. present(nlconstr0) .and. all(is_finite(x))) then
     f_loc = moderatef(f0)
+    constr_loc(1:m - m_nlcon) = moderatec(matprod(x, amat) - bvec)
     constr_loc(m - m_nlcon + 1:m) = moderatec(nlconstr0)
 else
     x = moderatex(x)
-    call evaluate(calcfc, x, f_loc, constr_loc(m - m_nlcon + 1:m))
+    call evaluate(calcfc, x, f_loc, constr_loc, amat, bvec)
+    constr_loc(1:m - m_nlcon) = moderatec(constr_loc(1:m - m_nlcon))
     ! N.B.: Do NOT call FMSG, SAVEHIST, or SAVEFILT for the function/constraint evaluation at X0.
     ! They will be called during the initialization, which will read the function/constraint at X0.
 end if

--- a/fortran/cobyla/initialize.f90
+++ b/fortran/cobyla/initialize.f90
@@ -19,7 +19,7 @@ public :: initxfc, initfilt
 contains
 
 
-subroutine initxfc(calcfc, iprint, maxfun, constr0, ctol, f0, ftarget, rhobeg, x0, nf, chist, &
+subroutine initxfc(calcfc, iprint, maxfun, constr0, amat, bvec, ctol, f0, ftarget, rhobeg, x0, nf, chist, &
     & conhist, conmat, cval, fhist, fval, sim, simi, xhist, evaluated, info)
 !--------------------------------------------------------------------------------------------------!
 ! This subroutine does the initialization concerning X, function values, and constraints.
@@ -44,6 +44,8 @@ procedure(OBJCON) :: calcfc ! N.B.: INTENT cannot be specified if a dummy proced
 integer(IK), intent(in) :: iprint
 integer(IK), intent(in) :: maxfun
 real(RP), intent(in) :: constr0(:)  ! CONSTR0(M)
+real(RP), intent(in) :: amat(:, :)
+real(RP), intent(in) :: bvec(:)
 real(RP), intent(in) :: ctol
 real(RP), intent(in) :: f0
 real(RP), intent(in) :: ftarget
@@ -156,7 +158,7 @@ do k = 1, n + 1_IK
     else
         j = k - 1_IK
         x(j) = x(j) + rhobeg
-        call evaluate(calcfc, x, f, constr)
+        call evaluate(calcfc, x, f, constr, amat, bvec)
     end if
     cstrv = maximum([ZERO, constr])
 


### PR DESCRIPTION
This is in support of efforts to integrate PRIMA with SciPy. They provide wheels for musl, and in musl you cannot have nested functions in Fortran (at least, not without gcc 14, which is cutting edge, and therefore it's not practical for scipy to switch to it).