### PR TITLE
add `meson.build` to define `pyprima` sources for downstream vendoring

### DIFF
--- a/pyprima/meson.build
+++ b/pyprima/meson.build
@@ -1,0 +1,43 @@
+project(
+  'pyprima',
+  version: '0.0.1',
+  license: 'BSD-3-Clause',
+  license_files: '../LICENCE.txt',
+)
+
+sources = {
+  'pyprima': files(
+    'src/pyprima/__init__.py',
+  ),
+
+  'pyprima/common': files(
+    'src/pyprima/common/__init__.py',
+    'src/pyprima/common/_bounds.py',
+    'src/pyprima/common/_linear_constraints.py',
+    'src/pyprima/common/_nonlinear_constraints.py',
+    'src/pyprima/common/_project.py',
+    'src/pyprima/common/checkbreak.py',
+    'src/pyprima/common/consts.py',
+    'src/pyprima/common/evaluate.py',
+    'src/pyprima/common/history.py',
+    'src/pyprima/common/infos.py',
+    'src/pyprima/common/linalg.py',
+    'src/pyprima/common/message.py',
+    'src/pyprima/common/powalg.py',
+    'src/pyprima/common/preproc.py',
+    'src/pyprima/common/present.py',
+    'src/pyprima/common/ratio.py',
+    'src/pyprima/common/redrho.py',
+    'src/pyprima/common/selectx.py',
+  ),
+
+  'pyprima/cobyla': files(
+    'src/pyprima/cobyla/__init__.py',
+    'src/pyprima/cobyla/cobyla.py',
+    'src/pyprima/cobyla/cobylb.py',
+    'src/pyprima/cobyla/geometry.py',
+    'src/pyprima/cobyla/initialize.py',
+    'src/pyprima/cobyla/trustregion.py',
+    'src/pyprima/cobyla/update.py',
+  ),
+}


### PR DESCRIPTION
Hi @nbelakovski @zaikunzhang, currently in SciPy we are maintaining a simple meson.build file which wraps around the pyprima source to integrate it with our meson build system. This PR moves that file into this repo, which will allow us to wrap pyprima directly, and enable other projects which use Meson to easily do the same.

Are you happy having the file in this repo? There is no obligation to keep it up to date, I'm sure SciPy maintainers can send a PR if needed. It does make sense to have the list of sources maintained in the same repo as the sources IMO.
