### PR TITLE
Fix missing `_RP` kind suffix on floating-point literals that are not binary-representable.

### DIFF
--- a/fortran/bobyqa/bobyqb.f90
+++ b/fortran/bobyqa/bobyqb.f90
@@ -330,7 +330,7 @@ do tr = 1, maxtr
     ! Set QRED to the reduction of the quadratic model when the move D is made from XOPT. QRED
     ! should be positive. If it is nonpositive due to rounding errors, we will not take this step.
     qred = -quadinc(d, xpt, gopt, pq, hq)  ! QRED = Q(XOPT) - Q(XOPT + D)
-    trfail = (.not. qred > 1.0E-6 * rho**2)  ! QRED is tiny/negative or NaN.
+    trfail = (.not. qred > 1.0E-6_RP * rho**2)  ! QRED is tiny/negative or NaN.
 
     ! When D is short, make a choice between reducing RHO and improving the geometry depending
     ! on whether or not our work with the current RHO seems complete. RHO is reduced if the

--- a/fortran/bobyqa/geometry.f90
+++ b/fortran/bobyqa/geometry.f90
@@ -491,9 +491,9 @@ den_line = calden(kopt, bmat, d, xpt, zmat)
 ! How to make this condition adaptive? A naive idea is to replace the thresholds to,
 ! e.g.,1.0E-2*RHOBEG. However, in a test on 20220517, this adaptation worsened the performance. In
 ! such a test, RHOBEG must take a value that is quite different from one. We tried RHOBEG = 0.9E-2.
-!if (delbar > 1.0E-3) then
-!if (delbar > 1.0E-1) then
-if (delbar > 1.0E-2) then
+!if (delbar > 1.0E-3_RP) then
+!if (delbar > 1.0E-1_RP) then
+if (delbar > 1.0E-2_RP) then
     return
 end if
 !--------------------------------------------------------------------------------------------------!

--- a/fortran/bobyqa/rescue.f90
+++ b/fortran/bobyqa/rescue.f90
@@ -499,7 +499,7 @@ if (nprov > 0) then
         ! Skipping an XNEW that is close but not identical to XPT(:, KPT) will cause discrepancy
         ! between [BMAT, ZMAT] and XPT, since the former has been updated, but it is not severe as
         ! the difference between XNEW and XPT(:, KPT) is tiny.
-        if (sum(abs(xnew - xpt(:, kpt))) <= 1.0E-2 * delta .or. .not. is_finite(sum(abs(xnew)))) then
+        if (sum(abs(xnew - xpt(:, kpt))) <= 1.0E-2_RP * delta .or. .not. is_finite(sum(abs(xnew)))) then
             cycle
         end if
         xpt(:, kpt) = xnew
@@ -747,7 +747,7 @@ vlag(knew) = vlag(knew) - ONE
 ! Apply Givens rotations to put zeros in the KNEW-th row of ZMAT. After this, ZMAT(KNEW, :) contains
 ! only one nonzero at ZMAT(KNEW, 1). Entries of ZMAT are treated as 0 if the moduli are quite small.
 do j = 2, npt - n - 1_IK
-    if (abs(zmat(knew, j)) > 1.0E-20 * maxval(abs(zmat))) then  ! This threshold is by Powell
+    if (abs(zmat(knew, j)) > 1.0E-20_RP * maxval(abs(zmat))) then  ! This threshold is by Powell
         grot = planerot(zmat(knew, [1_IK, j]))
         zmat(:, [1_IK, j]) = matprod(zmat(:, [1_IK, j]), transpose(grot))
     end if

--- a/fortran/bobyqa/update.f90
+++ b/fortran/bobyqa/update.f90
@@ -153,7 +153,7 @@ call symmetrize(bmat(:, npt + 1:npt + n))
 ! Apply Givens rotations to put zeros in the KNEW-th row of ZMAT. After this, ZMAT(KNEW, :) contains
 ! only one nonzero at ZMAT(KNEW, 1). Entries of ZMAT are treated as 0 if the moduli are quite small.
 do j = 2, npt - n - 1_IK
-    if (abs(zmat(knew, j)) > 1.0E-20 * maxval(abs(zmat))) then  ! This threshold is by Powell
+    if (abs(zmat(knew, j)) > 1.0E-20_RP * maxval(abs(zmat))) then  ! This threshold is by Powell
         grot = planerot(zmat(knew, [1_IK, j]))
         zmat(:, [1_IK, j]) = matprod(zmat(:, [1_IK, j]), transpose(grot))
     end if

--- a/fortran/cobyla/cobylb.f90
+++ b/fortran/cobyla/cobylb.f90
@@ -368,7 +368,7 @@ do tr = 1, maxtr
     ! Evaluate PREREM, which is the predicted reduction in the merit function.
     ! In theory, PREREM >= 0 and it is 0 iff CPEN = 0 = PREREF. This may not be true numerically.
     prerem = preref + cpen * prerec
-    trfail = (.not. prerem > 1.0E-6 * min(cpen, ONE) * rho)  ! PREREM is tiny/negative or NaN.
+    trfail = (.not. prerem > 1.0E-6_RP * min(cpen, ONE) * rho)  ! PREREM is tiny/negative or NaN.
 
     if (shortd .or. trfail) then
         ! Reduce DELTA if D is short or D fails to render PREREM > 0. The latter can happen due to
@@ -387,7 +387,7 @@ do tr = 1, maxtr
         distsq(1:n) = [(sum((x - (sim(:, n + 1) + sim(:, j)))**2), j=1, n)]  ! Implied do-loop
         !!MATLAB: distsq(1:n) = sum((x - (sim(:,1:n) + sim(:, n+1)))**2, 1)  % Implicit expansion
         j = int(minloc(distsq, dim=1), kind(j))
-        if (distsq(j) <= (1.0E-4 * rhoend)**2) then
+        if (distsq(j) <= (1.0E-4_RP * rhoend)**2) then
             f = fval(j)
             constr = conmat(:, j)
             cstrv = cval(j)
@@ -582,7 +582,7 @@ do tr = 1, maxtr
         distsq(1:n) = [(sum((x - (sim(:, n + 1) + sim(:, j)))**2), j=1, n)]  ! Implied do-loop
         !!MATLAB: distsq(1:n) = sum((x - (sim(:,1:n) + sim(:, n+1)))**2, 1)  % Implicit expansion
         j = int(minloc(distsq, dim=1), kind(j))
-        if (distsq(j) <= (1.0E-4 * rhoend)**2) then
+        if (distsq(j) <= (1.0E-4_RP * rhoend)**2) then
             f = fval(j)
             constr = conmat(:, j)
             cstrv = cval(j)

--- a/fortran/common/powalg.f90
+++ b/fortran/common/powalg.f90
@@ -1272,7 +1272,7 @@ do j = 2, npt - n - 1_IK
 
     ! Powell's condition in NEWUOA/LINCOA for the IF ... THEN below: IF (ZMAT(KNEW, J) /= 0) THEN
     ! A possible alternative: IF (ABS(ZMAT(KNEW, J)) > 1.0E-20 * ABS(ZMAT(KNEW, JL))) THEN
-    if (abs(zmat(knew, j)) > 1.0E-20 * maxval(abs(zmat))) then  ! Threshold comes from Powell's BOBYQA
+    if (abs(zmat(knew, j)) > 1.0E-20_RP * maxval(abs(zmat))) then  ! Threshold comes from Powell's BOBYQA
         ! Multiply a Givens rotation to ZMAT from the right so that ZMAT(KNEW, [JL,J]) becomes [*,0].
         grot = planerot(zmat(knew, [jl, j]))  !!MATLAB: grot = planerot(zmat(knew, [jl, j])')
         zmat(:, [jl, j]) = matprod(zmat(:, [jl, j]), transpose(grot))

--- a/fortran/common/string.f90
+++ b/fortran/common/string.f90
@@ -151,7 +151,7 @@ ndgt_loc = min(ndgt_loc, floor(real(MAX_NUM_STR_LEN - 5) / 2.0))  ! Safeguard
 if (present(nexp)) then
     nexp_loc = nexp
 else
-    nexp_loc = ceiling(log10(real(range(x) + 0.1)))  ! Use + 0.1 in case RANGE(X) = 10^k.
+    nexp_loc = ceiling(log10(real(range(x) + 0.1_RP)))  ! Use + 0.1 in case RANGE(X) = 10^k.
 end if
 nexp_loc = min(nexp_loc, floor(real(MAX_NUM_STR_LEN - 5) / 2.0))
 
@@ -254,7 +254,7 @@ ndgt_loc = min(ndgt_loc, floor(real(MAX_NUM_STR_LEN - 5) / 2.0))  ! Safeguard
 if (present(nexp)) then
     nexp_loc = nexp
 else
-    nexp_loc = ceiling(log10(real(range(x)) + 0.1))  ! Use + 0.1 in case RANGE(X) = 10^k.
+    nexp_loc = ceiling(log10(real(range(x)) + 0.1_RP))  ! Use + 0.1 in case RANGE(X) = 10^k.
 end if
 nexp_loc = min(nexp_loc, floor(real(MAX_NUM_STR_LEN - 5) / 2.0))
 

--- a/fortran/lincoa/lincob.f90
+++ b/fortran/lincoa/lincob.f90
@@ -429,7 +429,7 @@ do tr = 1, maxtr
     ! Set QRED to the reduction of the quadratic model when the move D is made from XOPT. QRED
     ! should be positive. If it is nonpositive due to rounding errors, we will not take this step.
     qred = -quadinc(d, xpt, gopt, pq, hq)  ! QRED = Q(XOPT) - Q(XOPT + D)
-    trfail = (.not. qred > 1.0E-6 * rho**2)  ! QRED is tiny/negative or NaN.
+    trfail = (.not. qred > 1.0E-6_RP * rho**2)  ! QRED is tiny/negative or NaN.
 
     if (shortd .or. trfail) then
         ! In this case, do nothing but reducing DELTA. Afterward, DELTA < DNORM may occur.
@@ -534,7 +534,7 @@ do tr = 1, maxtr
     ! verify a curvature condition that really indicates that recent models are sufficiently
     ! accurate. Here, however, we are not really sure whether they are accurate or not. Therefore,
     ! ACCURATE_MOD is not the best name, but we keep it to align with the other solvers.
-    accurate_mod = all(dnorm_rec <= rho) .or. all(dnorm_rec(2:size(dnorm_rec)) <= 0.2 * rho)
+    accurate_mod = all(dnorm_rec <= rho) .or. all(dnorm_rec(2:size(dnorm_rec)) <= 0.2_RP * rho)
     ! Powell's version (note that size(dnorm_rec) = 5 in his implementation):
     !accurate_mod = all(dnorm_rec <= HALF * rho) .or. all(dnorm_rec(3:size(dnorm_rec)) <= TENTH * rho)
     ! CLOSE_ITPSET: Are the interpolation points close to XOPT?

--- a/fortran/newuoa/newuob.f90
+++ b/fortran/newuoa/newuob.f90
@@ -287,7 +287,7 @@ do tr = 1, maxtr
     ! Set QRED to the reduction of the quadratic model when the move D is made from XOPT. QRED
     ! should be positive. If it is nonpositive due to rounding errors, we will not take this step.
     qred = -quadinc(d, xpt, gopt, pq, hq)
-    trfail = (.not. qred > 1.0E-6 * rho**2)  ! QRED is tiny/negative, or NaN.
+    trfail = (.not. qred > 1.0E-6_RP * rho**2)  ! QRED is tiny/negative, or NaN.
 
     if (shortd .or. trfail) then
         ! In this case, do nothing but reducing DELTA. Afterward, DELTA < DNORM may occur.
@@ -306,7 +306,7 @@ do tr = 1, maxtr
         distsq = [(sum((x - (xbase + xpt(:, k)))**2, dim=1), k=1, npt)]  ! Implied do-loop
         !!MATLAB: distsq = sum((x - (xbase + xpt))**2, 1)  % Implicit expansion
         k = int(minloc(distsq, dim=1), kind(k))
-        if (distsq(k) <= (1.0E-3 * rhoend)**2) then
+        if (distsq(k) <= (1.0E-3_RP * rhoend)**2) then
             f = fval(k)
         else
             ! Evaluate the objective function at X, taking care of possible Inf/NaN values.
@@ -553,7 +553,7 @@ do tr = 1, maxtr
         distsq = [(sum((x - (xbase + xpt(:, k)))**2, dim=1), k=1, npt)]  ! Implied do-loop
         !!MATLAB: distsq = sum((x - (xbase + xpt))**2, 1)  % Implicit expansion
         k = int(minloc(distsq, dim=1), kind(k))
-        if (distsq(k) <= (1.0E-3 * rhoend)**2) then
+        if (distsq(k) <= (1.0E-3_RP * rhoend)**2) then
             f = fval(k)
         else
             ! Evaluate the objective function at X, taking care of possible Inf/NaN values.

--- a/fortran/tests/test_bobyqa.f90
+++ b/fortran/tests/test_bobyqa.f90
@@ -238,10 +238,10 @@ else
             iprint = int(randn(), kind(iprint))
             maxfun = int(1.0E2_RP * rand() * real(n, RP), kind(maxfun))
             maxhist = int(TWO * rand() * real(max(10_IK * n, maxfun), RP), kind(maxhist))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 maxhist = -maxhist
             end if
-            if (rand() <= 0.8) then
+            if (rand() <= 0.8_RP) then
                 ftarget = -TEN**abs(real(min(range(ftarget), 12), RP) * rand())
             elseif (rand() <= 0.5) then  ! Note that the value of rand() changes.
                 ftarget = REALMAX
@@ -251,9 +251,9 @@ else
 
             rhobeg = noisy(prob % Delta0)
             rhoend = max(1.0E-5_RP, rhobeg * 10.0_RP**(6.0_RP * rand() - 5.0_RP))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 rhoend = rhobeg
-            elseif (rand() <= 0.1) then  ! Note that the value of rand() changes.
+            elseif (rand() <= 0.1_RP) then  ! Note that the value of rand() changes.
                 rhobeg = ZERO
             end if
 

--- a/fortran/tests/test_cobyla.f90
+++ b/fortran/tests/test_cobyla.f90
@@ -262,21 +262,21 @@ else
             iprint = int(randn(), kind(iprint))
             maxfun = int(1.0E2_RP * rand() * real(n, RP), kind(maxfun))
             maxhist = int(TWO * rand() * real(max(10_IK * n, maxfun), RP), kind(maxhist))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 maxhist = -maxhist
             end if
             maxfilt = int(TWO * rand() * real(maxfun, RP), kind(maxfilt))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 maxfilt = 0
             end if
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 ctol = randn() * TEN**(-abs(TWO * randn()))
-            elseif (rand() <= 0.1) then  ! Note that the value of rand() changes.
+            elseif (rand() <= 0.1_RP) then  ! Note that the value of rand() changes.
                 ctol = REALMAX
             else
                 ctol = ZERO
             end if
-            if (rand() <= 0.8) then
+            if (rand() <= 0.8_RP) then
                 ftarget = -TEN**abs(real(min(range(ftarget), 12), RP) * rand())
             elseif (rand() <= 0.5) then  ! Note that the value of rand() changes.
                 ftarget = REALMAX
@@ -286,9 +286,9 @@ else
 
             rhobeg = noisy(prob % Delta0)
             rhoend = max(1.0E-5_RP, rhobeg * 10.0_RP**(6.0_RP * rand() - 5.0_RP))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 rhoend = rhobeg
-            elseif (rand() <= 0.1) then  ! Note that the value of rand() changes.
+            elseif (rand() <= 0.1_RP) then  ! Note that the value of rand() changes.
                 rhobeg = ZERO
             end if
 

--- a/fortran/tests/test_lincoa.f90
+++ b/fortran/tests/test_lincoa.f90
@@ -303,21 +303,21 @@ else
             iprint = int(randn(), kind(iprint))
             maxfun = int(1.0E2_RP * rand() * real(n, RP), kind(maxfun))
             maxhist = int(TWO * rand() * real(max(10_IK * n, maxfun), RP), kind(maxhist))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 maxhist = -maxhist
             end if
             maxfilt = int(TWO * rand() * real(maxfun, RP), kind(maxfilt))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 maxfilt = 0
             end if
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 ctol = randn() * TEN**(-abs(TWO * randn()))
-            elseif (rand() <= 0.1) then  ! Note that the value of rand() changes.
+            elseif (rand() <= 0.1_RP) then  ! Note that the value of rand() changes.
                 ctol = REALMAX
             else
                 ctol = ZERO
             end if
-            if (rand() <= 0.8) then
+            if (rand() <= 0.8_RP) then
                 ftarget = -TEN**abs(real(min(range(ftarget), 12), RP) * rand())
             elseif (rand() <= 0.5) then  ! Note that the value of rand() changes.
                 ftarget = REALMAX
@@ -327,9 +327,9 @@ else
 
             rhobeg = noisy(prob % Delta0)
             rhoend = max(1.0E-5_RP, rhobeg * 10.0_RP**(6.0_RP * rand() - 5.0_RP))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 rhoend = rhobeg
-            elseif (rand() <= 0.1) then  ! Note that the value of rand() changes.
+            elseif (rand() <= 0.1_RP) then  ! Note that the value of rand() changes.
                 rhobeg = ZERO
             end if
 

--- a/fortran/tests/test_newuoa.f90
+++ b/fortran/tests/test_newuoa.f90
@@ -215,10 +215,10 @@ else
             iprint = int(randn(), kind(iprint))
             maxfun = int(1.0E2_RP * rand() * real(n, RP), kind(maxfun))
             maxhist = int(TWO * rand() * real(max(10_IK * n, maxfun), RP), kind(maxhist))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 maxhist = -maxhist
             end if
-            if (rand() <= 0.8) then
+            if (rand() <= 0.8_RP) then
                 ftarget = -TEN**abs(real(min(range(ftarget), 12), RP) * rand())
             elseif (rand() <= 0.5) then  ! Note that the value of rand() changes.
                 ftarget = REALMAX
@@ -228,9 +228,9 @@ else
 
             rhobeg = noisy(prob % Delta0)
             rhoend = max(1.0E-5_RP, rhobeg * 10.0_RP**(6.0_RP * rand() - 5.0_RP))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 rhoend = rhobeg
-            elseif (rand() <= 0.1) then  ! Note that the value of rand() changes.
+            elseif (rand() <= 0.1_RP) then  ! Note that the value of rand() changes.
                 rhobeg = ZERO
             end if
 

--- a/fortran/tests/test_uobyqa.f90
+++ b/fortran/tests/test_uobyqa.f90
@@ -199,10 +199,10 @@ else
             iprint = int(randn(), kind(iprint))
             maxfun = int(1.0E2_RP * rand() * real(n, RP), kind(maxfun))
             maxhist = int(TWO * rand() * real(max(10_IK * n, maxfun), RP), kind(maxhist))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 maxhist = -maxhist
             end if
-            if (rand() <= 0.8) then
+            if (rand() <= 0.8_RP) then
                 ftarget = -TEN**abs(real(min(range(ftarget), 12), RP) * rand())
             elseif (rand() <= 0.5) then  ! Note that the value of rand() changes.
                 ftarget = REALMAX
@@ -212,9 +212,9 @@ else
 
             rhobeg = noisy(prob % Delta0)
             rhoend = max(1.0E-5_RP, rhobeg * 10.0_RP**(6.0_RP * rand() - 5.0_RP))
-            if (rand() <= 0.1) then
+            if (rand() <= 0.1_RP) then
                 rhoend = rhobeg
-            elseif (rand() <= 0.1) then  ! Note that the value of rand() changes.
+            elseif (rand() <= 0.1_RP) then  ! Note that the value of rand() changes.
                 rhobeg = ZERO
             end if
 

--- a/fortran/uobyqa/uobyqb.f90
+++ b/fortran/uobyqa/uobyqb.f90
@@ -294,7 +294,7 @@ do tr = 1, maxtr
     ! Set QRED to the reduction of the quadratic model when the move D is made from XOPT. QRED
     ! should be positive. If it is nonpositive due to rounding errors, we will not take this step.
     qred = -quadinc(pq, d, xpt(:, kopt))  ! QRED = Q(XOPT) - Q(XOPT + D)
-    trfail = (.not. qred > 1.0E-6 * rho**2)  ! QRED is tiny/negative or NaN.
+    trfail = (.not. qred > 1.0E-6_RP * rho**2)  ! QRED is tiny/negative or NaN.
 
     if (shortd .or. trfail) then
         ! Powell's code does not reduce DELTA as follows. This comes from NEWUOA and works well.
@@ -310,7 +310,7 @@ do tr = 1, maxtr
         distsq = [(sum((x - (xbase + xpt(:, k)))**2, dim=1), k=1, npt)]  ! Implied do-loop
         !!MATLAB: distsq = sum((x - (xbase + xpt))**2, 1)  % Implicit expansion
         k = int(minloc(distsq, dim=1), kind(k))
-        if (distsq(k) <= (1.0E-4 * rhoend)**2) then
+        if (distsq(k) <= (1.0E-4_RP * rhoend)**2) then
             f = fval(k)
         else
             ! Evaluate the objective function at X, taking care of possible Inf/NaN values.
@@ -474,7 +474,7 @@ do tr = 1, maxtr
         distsq = [(sum((x - (xbase + xpt(:, k)))**2, dim=1), k=1, npt)]  ! Implied do-loop
         !!MATLAB: distsq = sum((x - (xbase + xpt))**2, 1)  % Implicit expansion
         k = int(minloc(distsq, dim=1), kind(k))
-        if (distsq(k) <= (1.0E-4 * rhoend)**2) then
+        if (distsq(k) <= (1.0E-4_RP * rhoend)**2) then
             f = fval(k)
         else
             ! Evaluate the objective function at X, taking care of possible Inf/NaN values.


### PR DESCRIPTION
In Fortran, an unsuffixed literal like `0.1` is of type `default real` (usually 32-bit single precision). When `RP` is configured as 64-bit double precision, comparing or combining `real(RP)` variables with unsuffixed literals triggers an implicit type conversion. Worse, `0.1` in single precision and `0.1_RP` in double precision are different binary approximations. This means a condition such as

```fortran
if (rand() <= 0.1) then
```

may evaluate differently in rare cases.

This PR appends `_RP` to unsuffixed floating-point literals that is not exactly
representable in binary.

## How They Were Detected

The missing suffixes were identified by [fortran_float_number_extract](https://github.com/chenyu76/fortran_float_number_extract), a simple tool that

1. parses Fortran source files into an AST using [`fortran-src`](https://hackage.haskell.org/package/fortran-src),
2. traverses the AST to find all real/integer literals without a kind suffix,
3. checks whether those literals can be exactly represented in binary form and reports them if not.

After identification, I manually checked whether each literal needed to be rewritten.

### Literals that were skipped

- The literal `0.9` in `/fortran/tests/testsuite/bigprob.f90:23:43`.
- The original code by Prof. Powell in `/fortran/original/`.